### PR TITLE
Support for blueprints

### DIFF
--- a/openVCB.h
+++ b/openVCB.h
@@ -173,6 +173,12 @@ namespace openVCB {
 		// Builds a project from an image. Remember to configure VMem
 		void readFromVCB(std::string p);
 
+		// Decode base64 data from clipboard, then process logic data
+		void readFromBlueprint(std::string clipboardData);
+
+		// Decompress zstd data to an image
+		bool processLogicData(std::vector<unsigned char> logicData, int headerSize);
+
 		// Samples the ink at a pixel. Returns ink and group id
 		std::pair<Ink, int> sample(glm::ivec2 pos);
 

--- a/openVCB.vcxproj
+++ b/openVCB.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="opennVCBAssembler.cpp" />
     <ClCompile Include="openVCB.cpp" />
+    <ClCompile Include="openVCBBlueprint.cpp" />
     <ClCompile Include="openVCBExpr.cpp" />
     <ClCompile Include="openVCBPreprocessing.cpp" />
     <ClCompile Include="openVCBReader.cpp" />

--- a/openVCB.vcxproj.filters
+++ b/openVCB.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="gorder\Util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="openVCBBlueprint.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="openVCB.h">

--- a/openVCBBlueprint.cpp
+++ b/openVCBBlueprint.cpp
@@ -1,0 +1,42 @@
+#include "openVCB.h"
+
+namespace openVCB {
+    static const int B64index[256] = { 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 62, 63, 62, 62, 63, 52, 53, 54, 55,
+    56, 57, 58, 59, 60, 61,  0,  0,  0,  0,  0,  0,  0,  0,  1,  2,  3,  4,  5,  6,
+    7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  0,
+    0,  0,  0, 63,  0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
+
+    std::vector<unsigned char> b64decode(std::string data) {
+        const size_t len = data.length();
+        int pad = len > 0 && (len % 4 || data[len - 1] == '=');
+        
+        const size_t size = ((len + 3) / 4 - pad) * 4;
+        std::vector<unsigned char> result(size / 4 * 3 + pad);
+
+        for (size_t i = 0, j = 0; i < size; i += 4) {
+            int n = B64index[data[i]] << 18 | B64index[data[i + 1]] << 12 | B64index[data[i + 2]] << 6 | B64index[data[i + 3]];
+            result[j++] = n >> 16;
+            result[j++] = n >> 8 & 0xFF;
+            result[j++] = n & 0xFF;
+        }
+
+        if (pad) {
+            int n = B64index[data[size]] << 18 | B64index[data[size + 1]] << 12;
+            result[result.size() - 1] = n >> 16;
+
+            if (len > size + 2 && data[size + 2] != '=') {
+                n |= B64index[data[size + 2]] << 6;
+                result.push_back(n >> 8 & 0xFF);
+            }
+        }
+        return result;
+    }
+
+    void Project::readFromBlueprint(std::string clipboardData) {
+        std::vector<unsigned char> logicData = b64decode(clipboardData);
+        Project::processLogicData(logicData, 32);
+    }
+}


### PR DESCRIPTION
Summary of what has been done : 

- A new class `openVCBBlueprint` has been created. It decode base64 data from clipboard then process data (which is just an image). Excepted usage is : `proj->readFromBlueprint(clipboardContent)`. Ideally, it should be called once user press CTRL-V (any already loaded data should be cleared before). 

- Some code from `project::readFromVCB()` has been moved to `processLogicData` method.

Main difference between blueprints and regular vcb files is header position (24 vs 32)
I did my best to change as little code as possible.